### PR TITLE
remove PlatformTarget

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>cuo</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
     <PublishAot>true</PublishAot>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Leave .NET's default "anycpu"
(https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/output#platformtarget) which builds executables for the build host.

Hard-coding this to "x64" prevents the client from running on ARM64.