### PR TITLE
IO/DataReader: implement IDisposable

### DIFF
--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -739,9 +739,14 @@ namespace ClassicUO.Game
                 }
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                MapLoader.Instance.Dispose();
+                if (disposing)
+                {
+                    MapLoader.Instance.Dispose();
+                }
+
+                base.Dispose(disposing);
             }
 
             public void WriteArray(long position, ArraySegment<byte> seg)

--- a/src/ClassicUO.IO/DataReader.cs
+++ b/src/ClassicUO.IO/DataReader.cs
@@ -41,7 +41,7 @@ namespace ClassicUO.IO
     /// <summary>
     ///     A fast Little Endian data reader.
     /// </summary>
-    public unsafe class DataReader
+    public unsafe class DataReader : IDisposable
     {
         private byte* _data;
         private GCHandle _handle;
@@ -56,8 +56,24 @@ namespace ClassicUO.IO
 
         public bool IsEOF => Position >= Length;
 
+        ~DataReader()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            ReleaseData();
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ReleaseData()
+        private void ReleaseData()
         {
             if (_handle.IsAllocated)
             {

--- a/src/ClassicUO.IO/UOFile.cs
+++ b/src/ClassicUO.IO/UOFile.cs
@@ -104,14 +104,35 @@ namespace ClassicUO.IO
             }
         }
 
-        public virtual void Dispose()
+        protected override void Dispose(bool disposing)
         {
+            bool hasAcquiredPointer = StartAddress != IntPtr.Zero;
+
+            base.Dispose(disposing);
+
 #if USE_MMF
-            _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-            _accessor.Dispose();
-            _file.Dispose();
+            if (hasAcquiredPointer) {
+                _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            }
 #endif
-            Log.Trace($"Unloaded:\t\t{FilePath}");
+
+            if (disposing)
+            {
+#if USE_MMF
+                if (_accessor != null)
+                {
+                    _accessor.Dispose();
+                    _accessor = null;
+                }
+
+                if (_file != null)
+                {
+                    _file.Dispose();
+                    _file = null;
+                }
+#endif
+                Log.Trace($"Unloaded:\t\t{FilePath}");
+            }
         }
     }
 }

--- a/src/ClassicUO.IO/UOFileMul.cs
+++ b/src/ClassicUO.IO/UOFileMul.cs
@@ -77,10 +77,14 @@ namespace ClassicUO.IO
             }
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            _idxFile?.Dispose();
-            base.Dispose();
+            if (disposing)
+            {
+                _idxFile?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         private class UOFileIdxMul : UOFile

--- a/src/ClassicUO.IO/UOFileUop.cs
+++ b/src/ClassicUO.IO/UOFileUop.cs
@@ -151,10 +151,14 @@ namespace ClassicUO.IO
             _hashes.Clear();
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            ClearHashes();
-            base.Dispose();
+            if (disposing)
+            {
+                ClearHashes();
+            }
+
+            base.Dispose(disposing);
         }
 
 


### PR DESCRIPTION
This moves the Dispose() method one class level up; previously, it was a virtual method in class UOFile, but .NET documentation says Dispose() must not be virtual:

 https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-idisposable

Instead, one should have a virtual Dispose(bool) method.

Also, this patch makes ReleaseData() private because nobody calls it from the outside.