### PR TITLE
Assets/FontLoader: fix use-after-free crash bug

### DIFF
--- a/src/ClassicUO.Assets/FontsLoader.cs
+++ b/src/ClassicUO.Assets/FontsLoader.cs
@@ -103,6 +103,12 @@ namespace ClassicUO.Assets
 
         private HtmlStatus _htmlStatus;
 
+        /* these variables are not actually used; they only exist to
+           hold a reference on the memory mappings to keep the GC from
+           releasing them */
+        private DataReader fonts;
+        private readonly DataReader[] uniFonts = new DataReader[20];
+
         private FontCharacterData[,] _fontData;
         private readonly IntPtr[] _unicodeFontAddress = new IntPtr[20];
         private readonly long[] _unicodeFontSize = new long[20];
@@ -114,6 +120,12 @@ namespace ClassicUO.Assets
 
         public void Dispose()
         {
+            fonts?.Dispose();
+
+            foreach (var uniFont in uniFonts)
+            {
+                uniFont?.Dispose();
+            }
         }
 
         public static FontsLoader Instance => _instance ?? (_instance = new FontsLoader());
@@ -130,8 +142,7 @@ namespace ClassicUO.Assets
         {
             return Task.Run(() =>
             {
-                var fonts = new UOFile(UOFileManager.GetUOFilePath("fonts.mul"));
-                var uniFonts = new UOFile[20];
+                fonts = new UOFile(UOFileManager.GetUOFilePath("fonts.mul"));
 
                 for (int i = 0; i < 20; i++)
                 {


### PR DESCRIPTION
This fixes a bug that has been present since the very first ClassicUO version; the faulty code was added by commit 5869b9c7898; previously, there was some draft code without this bug, but it was removed by the commit.

The method Load() creates 21 UOFile objects which map all 21 font files into memory.  Then pointers into this memory mapping are stored in _fontData and _unicodeFontAddress.  When Load() returns, the last reference to these UOFile objects is released and they are subject to garbage collection.

Eventually, when the garbage collector kicks in, all UOFile instances are destructed and the memory mappings are unmapped.  Any further access to this memory are will then either result in a crash or read garbage, if that memory region just happens to have been allocated by something else meanwhile.

The fix is simple: add variables holding references to these UOFile instances.