### PR TITLE
Lots of DataReader refactoring

### DIFF
--- a/src/ClassicUO.Assets/AnimDataLoader.cs
+++ b/src/ClassicUO.Assets/AnimDataLoader.cs
@@ -42,7 +42,7 @@ namespace ClassicUO.Assets
     public class AnimDataLoader : IDisposable
     {
         private static AnimDataLoader _instance;
-        private DataReader _file;
+        private PinnedBuffer _file;
 
         private AnimDataLoader()
         {
@@ -54,7 +54,7 @@ namespace ClassicUO.Assets
 
         public static AnimDataLoader Instance => _instance ?? (_instance = new AnimDataLoader());
 
-        public DataReader AnimDataFile => _file;
+        public PinnedBuffer AnimDataFile => _file;
 
         public Task Load()
         {

--- a/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -1301,8 +1301,6 @@ namespace ClassicUO.Assets
                 return Span<FrameInfo>.Empty;
             }
 
-            file.Seek(index.Position);
-
             if (_decompressedData == null || index.Unknown > _decompressedData.Length)
             {
                 _decompressedData = new byte[index.Unknown];
@@ -1311,7 +1309,7 @@ namespace ClassicUO.Assets
             fixed (byte* ptr = _decompressedData.AsSpan())
             {
                 var result = ZLib.Decompress(
-                    file.PositionAddress,
+                    file.StartAddress + (IntPtr)index.Position,
                     (int)index.Size,
                     0,
                     (IntPtr)ptr,

--- a/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -57,8 +57,8 @@ namespace ClassicUO.Assets
         private static byte[] _decompressedData;
 
         private readonly bool[] filesLoaded = new bool[5];
-        private readonly DataReader[] _files = new DataReader[5];
-        private readonly DataReader[] _filesIdx = new DataReader[5];
+        private readonly PinnedBuffer[] _files = new PinnedBuffer[5];
+        private readonly PinnedBuffer[] _filesIdx = new PinnedBuffer[5];
         private readonly UOFileUop[] _filesUop = new UOFileUop[4];
 
         private readonly Dictionary<ushort, Dictionary<ushort, EquipConvData>> _equipConv = new Dictionary<ushort, Dictionary<ushort, EquipConvData>>();

--- a/src/ClassicUO.Assets/ArtLoader.cs
+++ b/src/ClassicUO.Assets/ArtLoader.cs
@@ -56,6 +56,12 @@ namespace ClassicUO.Assets
             _graphicMask = UOFileManager.IsUOPInstallation ? (ushort)0xFFFF : (ushort)0x3FFF;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _file?.Dispose();
+        }
+
         public static ArtLoader Instance =>
             _instance
             ?? (_instance = new ArtLoader(MAX_STATIC_DATA_INDEX_COUNT, MAX_LAND_DATA_INDEX_COUNT));

--- a/src/ClassicUO.Assets/ArtLoader.cs
+++ b/src/ClassicUO.Assets/ArtLoader.cs
@@ -42,7 +42,7 @@ namespace ClassicUO.Assets
     public class ArtLoader : UOFileLoader
     {
         private static ArtLoader _instance;
-        private DataReader _file;
+        private IDisposable _file;
         private readonly ushort _graphicMask;
 
         [ThreadStatic]
@@ -89,12 +89,14 @@ namespace ClassicUO.Assets
 
                     if (File.Exists(filePath) && File.Exists(idxPath))
                     {
-                        _file = new UOFile(filePath);
+                        var file = new UOFile(filePath);
 
                         using (var idxFile = new UOFile(idxPath))
                         {
-                            UOFileMul.FillEntries(_file, idxFile, ref Entries);
+                            UOFileMul.FillEntries(file, idxFile, ref Entries);
                         }
+
+                        _file = file;
                     }
                 }
             });

--- a/src/ClassicUO.Assets/FontsLoader.cs
+++ b/src/ClassicUO.Assets/FontsLoader.cs
@@ -132,7 +132,7 @@ namespace ClassicUO.Assets
     public sealed class UniFont : IDisposable
     {
         public const int SPACE_WIDTH = 8;
-        private readonly DataReader file;
+        private readonly PinnedBuffer file;
 
         public UniFont(string path)
         {
@@ -241,7 +241,7 @@ namespace ClassicUO.Assets
         /* these variables are not actually used; they only exist to
            hold a reference on the memory mappings to keep the GC from
            releasing them */
-        private DataReader fonts;
+        private PinnedBuffer fonts;
         private readonly UniFont[] uniFonts = new UniFont[20];
 
         private ASCIIFont[] asciiFonts;
@@ -269,7 +269,7 @@ namespace ClassicUO.Assets
 
         private bool IsUsingHTML { get; set; }
 
-        private static ASCIIFont[] LoadASCIIFonts(DataReader file)
+        private static ASCIIFont[] LoadASCIIFonts(PinnedBuffer file)
         {
             var ptr = file.StartAddress;
             var end = file.EndAddress;

--- a/src/ClassicUO.Assets/GumpsLoader.cs
+++ b/src/ClassicUO.Assets/GumpsLoader.cs
@@ -48,6 +48,12 @@ namespace ClassicUO.Assets
 
         private GumpsLoader(int count) { }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _file?.Dispose();
+        }
+
         public static GumpsLoader Instance =>
             _instance ?? (_instance = new GumpsLoader(MAX_GUMP_DATA_INDEX_COUNT));
 

--- a/src/ClassicUO.Assets/GumpsLoader.cs
+++ b/src/ClassicUO.Assets/GumpsLoader.cs
@@ -42,7 +42,7 @@ namespace ClassicUO.Assets
     public class GumpsLoader : UOFileLoader
     {
         private static GumpsLoader _instance;
-        private UOFile _file;
+        private IDisposable _file;
 
         public const int MAX_GUMP_DATA_INDEX_COUNT = 0x10000;
 
@@ -91,14 +91,15 @@ namespace ClassicUO.Assets
                         pathidx = UOFileManager.GetUOFilePath("Gumpidx.mul");
                     }
 
-                    _file = new UOFile(path);
+                    var file = new UOFile(path);
 
                     using (var idxFile = new UOFile(pathidx))
                     {
-                        UOFileMul.FillEntries(_file, idxFile, ref Entries);
+                        UOFileMul.FillEntries(file, idxFile, ref Entries);
                     }
 
                     UseUOPGumps = false;
+                    _file = file;
                 }
 
                 string pathdef = UOFileManager.GetUOFilePath("gump.def");

--- a/src/ClassicUO.Assets/HuesLoader.cs
+++ b/src/ClassicUO.Assets/HuesLoader.cs
@@ -61,7 +61,7 @@ namespace ClassicUO.Assets
 
         private FloatHues[] Palette;
 
-        private DataReader RadarCol;
+        private PinnedBuffer RadarCol;
 
         private void LoadHues()
         {

--- a/src/ClassicUO.Assets/LightsLoader.cs
+++ b/src/ClassicUO.Assets/LightsLoader.cs
@@ -40,7 +40,7 @@ namespace ClassicUO.Assets
     public class LightsLoader : UOFileLoader
     {
         private static LightsLoader _instance;
-        private DataReader _file;
+        private PinnedBuffer _file;
 
         public const int MAX_LIGHTS_DATA_INDEX_COUNT = 100;
 

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -111,6 +111,7 @@ namespace ClassicUO.Assets
             _fileIdxStatics?.Dispose();
             _mapDif?.Dispose();
             _mapDifl?.Dispose();
+            _staDif?.Dispose();
             _staDifi?.Dispose();
             _staDifl?.Dispose();
         }

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -324,22 +324,22 @@ namespace ClassicUO.Assets
                     return false;
                 }
 
+                mapPatchesCount = Math.Min(mapPatchesCount, (int) (dif.Length / sizeof(MapBlock)));
                 mapPatchesCount = Math.Min(mapPatchesCount, (int) difl.Length >> 2);
 
-                dif.Seek(0);
+                var mapBlockPtr = (MapBlock*)dif.StartAddress;
+                var diflPtr = (uint*)difl.StartAddress;
 
-                for (int j = 0; j < mapPatchesCount; j++)
+                for (int j = 0; j < mapPatchesCount; j++, mapBlockPtr++)
                 {
-                    uint blockIndex = difl.ReadUInt();
+                    uint blockIndex = *diflPtr++;
 
                     if (blockIndex < maxBlockCount)
                     {
-                        BlockData[blockIndex].MapAddress = dif.PositionAddress;
+                        BlockData[blockIndex].MapAddress = (IntPtr)mapBlockPtr;
 
                         result = true;
                     }
-
-                    dif.Skip(sizeof(MapBlock));
                 }
             }
 
@@ -354,23 +354,17 @@ namespace ClassicUO.Assets
 
                 IntPtr startAddress = _staDif.StartAddress;
 
+                staticPatchesCount = Math.Min(staticPatchesCount, (int)(difi.Length / sizeof(StaidxBlock)));
                 staticPatchesCount = Math.Min(staticPatchesCount, (int) difl.Length >> 2);
 
                 int sizeOfStaicsBlock = sizeof(StaticsBlock);
-                int sizeOfStaidxBlock = sizeof(StaidxBlock);
 
-                for (int j = 0; j < staticPatchesCount; j++)
+                var sidx = (StaidxBlock*)difi.StartAddress;
+                var diflPtr = (uint*)difl.StartAddress;
+
+                for (int j = 0; j < staticPatchesCount; j++, sidx++)
                 {
-                    if (difl.IsEOF || difi.IsEOF)
-                    {
-                        break;
-                    }
-
-                    uint blockIndex = difl.ReadUInt();
-
-                    StaidxBlock* sidx = (StaidxBlock*) difi.PositionAddress;
-
-                    difi.Skip(sizeOfStaidxBlock);
+                    uint blockIndex = *diflPtr++;
 
                     if (blockIndex < maxBlockCount)
                     {

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -49,14 +49,14 @@ namespace ClassicUO.Assets
         private readonly FileInfo mapFileInfo;
         public long MapFileLength => mapFileInfo.Length;
 
-        private DataReader _fileMap;
-        private DataReader _fileStatics;
-        private DataReader _fileIdxStatics;
+        private PinnedBuffer _fileMap;
+        private PinnedBuffer _fileStatics;
+        private PinnedBuffer _fileIdxStatics;
 
         private readonly bool isuop;
 
-        private DataReader _mapDif;
-        private DataReader _staDif;
+        private PinnedBuffer _mapDif;
+        private PinnedBuffer _staDif;
 
         public int Width { get; private set; }
         public int Height { get; private set; }
@@ -182,9 +182,9 @@ namespace ClassicUO.Assets
             int staticblocksize = sizeof(StaticsBlock);
             int maxblockcount = Width * Height;
             BlockData = new IndexMap[maxblockcount];
-            DataReader file = _fileMap;
-            DataReader fileidx = _fileIdxStatics;
-            DataReader staticfile = _fileStatics;
+            PinnedBuffer file = _fileMap;
+            PinnedBuffer fileidx = _fileIdxStatics;
+            PinnedBuffer staticfile = _fileStatics;
 
             if (inherit != null)
             {
@@ -317,8 +317,8 @@ namespace ClassicUO.Assets
 
             if (mapPatchesCount != 0 && _mapDif != null && _mapDif.HasData)
             {
-                DataReader dif = _mapDif;
-                using DataReader difl = new UOFile(UOFileManager.GetUOFilePath($"mapdifl{idx}.mul"));
+                PinnedBuffer dif = _mapDif;
+                using PinnedBuffer difl = new UOFile(UOFileManager.GetUOFilePath($"mapdifl{idx}.mul"));
                 if (!difl.HasData)
                 {
                     return false;
@@ -345,8 +345,8 @@ namespace ClassicUO.Assets
 
             if (staticPatchesCount != 0 && _staDif != null && _staDif.HasData)
             {
-                using DataReader difl = new UOFile(UOFileManager.GetUOFilePath($"stadifl{idx}.mul"));
-                using DataReader difi = new UOFile(UOFileManager.GetUOFilePath($"stadifi{idx}.mul"));
+                using PinnedBuffer difl = new UOFile(UOFileManager.GetUOFilePath($"stadifl{idx}.mul"));
+                using PinnedBuffer difi = new UOFile(UOFileManager.GetUOFilePath($"stadifi{idx}.mul"));
                 if (!difl.HasData || !difi.HasData)
                 {
                     return false;

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -56,10 +56,7 @@ namespace ClassicUO.Assets
         private readonly bool isuop;
 
         private DataReader _mapDif;
-        private DataReader _mapDifl;
         private DataReader _staDif;
-        private DataReader _staDifi;
-        private DataReader _staDifl;
 
         public int Width { get; private set; }
         public int Height { get; private set; }
@@ -110,10 +107,7 @@ namespace ClassicUO.Assets
             _fileStatics?.Dispose();
             _fileIdxStatics?.Dispose();
             _mapDif?.Dispose();
-            _mapDifl?.Dispose();
             _staDif?.Dispose();
-            _staDifi?.Dispose();
-            _staDifl?.Dispose();
         }
 
         public void SetSize(int width, int height)
@@ -137,15 +131,16 @@ namespace ClassicUO.Assets
                     _fileMap = new UOFile(path);
                 }
 
-                path = UOFileManager.GetUOFilePath($"mapdifl{i}.mul");
-
+                path = UOFileManager.GetUOFilePath($"mapdif{i}.mul");
                 if (File.Exists(path))
                 {
-                    _mapDifl = new UOFile(path);
-                    _mapDif = new UOFile(UOFileManager.GetUOFilePath($"mapdif{i}.mul"));
-                    _staDifl = new UOFile(UOFileManager.GetUOFilePath($"stadifl{i}.mul"));
-                    _staDifi = new UOFile(UOFileManager.GetUOFilePath($"stadifi{i}.mul"));
-                    _staDif = new UOFile(UOFileManager.GetUOFilePath($"stadif{i}.mul"));
+                    _mapDif = new UOFile(path);
+                }
+
+                path = UOFileManager.GetUOFilePath($"stadif{i}.mul");
+                if (File.Exists(path))
+                {
+                    _staDif = new UOFile(path);
                 }
             }
 
@@ -320,19 +315,17 @@ namespace ClassicUO.Assets
 
             int maxBlockCount = BlocksCount;
 
-            if (mapPatchesCount != 0)
+            if (mapPatchesCount != 0 && _mapDif != null && _mapDif.HasData)
             {
-                DataReader difl = _mapDifl;
                 DataReader dif = _mapDif;
-
-                if (difl == null || dif == null || difl.Length == 0 || dif.Length == 0)
+                using DataReader difl = new UOFile(UOFileManager.GetUOFilePath($"mapdifl{idx}.mul"));
+                if (!difl.HasData)
                 {
                     return false;
                 }
 
                 mapPatchesCount = Math.Min(mapPatchesCount, (int) difl.Length >> 2);
 
-                difl.Seek(0);
                 dif.Seek(0);
 
                 for (int j = 0; j < mapPatchesCount; j++)
@@ -350,12 +343,11 @@ namespace ClassicUO.Assets
                 }
             }
 
-            if (staticPatchesCount != 0)
+            if (staticPatchesCount != 0 && _staDif != null && _staDif.HasData)
             {
-                DataReader difl = _staDifl;
-                DataReader difi = _staDifi;
-
-                if (difl == null || difi == null || _staDif == null || difl.Length == 0 || difi.Length == 0 || _staDif.Length == 0)
+                using DataReader difl = new UOFile(UOFileManager.GetUOFilePath($"stadifl{idx}.mul"));
+                using DataReader difi = new UOFile(UOFileManager.GetUOFilePath($"stadifi{idx}.mul"));
+                if (!difl.HasData || !difi.HasData)
                 {
                     return false;
                 }
@@ -363,9 +355,6 @@ namespace ClassicUO.Assets
                 IntPtr startAddress = _staDif.StartAddress;
 
                 staticPatchesCount = Math.Min(staticPatchesCount, (int) difl.Length >> 2);
-
-                difl.Seek(0);
-                difi.Seek(0);
 
                 int sizeOfStaicsBlock = sizeof(StaticsBlock);
                 int sizeOfStaidxBlock = sizeof(StaidxBlock);

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -205,18 +205,18 @@ namespace ClassicUO.Assets
                 }
             }
 
-            ulong staticidxaddress = (ulong) fileidx.StartAddress;
-            ulong endstaticidxaddress = staticidxaddress + (ulong) fileidx.Length;
-            ulong staticaddress = (ulong) staticfile.StartAddress;
-            ulong endstaticaddress = staticaddress + (ulong) staticfile.Length;
-            ulong mapddress = (ulong) file.StartAddress;
-            ulong endmapaddress = mapddress + (ulong) file.Length;
-            ulong uopoffset = 0;
+            IntPtr staticidxaddress = fileidx.StartAddress;
+            IntPtr endstaticidxaddress = staticidxaddress + (IntPtr) fileidx.Length;
+            IntPtr staticaddress = staticfile.StartAddress;
+            IntPtr endstaticaddress = staticaddress + (IntPtr) staticfile.Length;
+            IntPtr mapddress = file.StartAddress;
+            IntPtr endmapaddress = mapddress + (IntPtr) file.Length;
+            IntPtr uopoffset = 0;
             int fileNumber = -1;
 
             for (int block = 0; block < maxblockcount; block++)
             {
-                ulong realmapaddress = 0, realstaticaddress = 0;
+                IntPtr realmapaddress = 0, realstaticaddress = 0;
                 uint realstaticcount = 0;
                 int blocknum = block;
 
@@ -236,25 +236,25 @@ namespace ClassicUO.Assets
 
                             if (uop.TryGetUOPData(hash, out var dataIndex))
                             {
-                                uopoffset = (ulong)dataIndex.Offset;
+                                uopoffset = (IntPtr)dataIndex.Offset;
                             }
                         }
                     }
                 }
 
-                ulong address = mapddress + uopoffset + (ulong) (blocknum * mapblocksize);
+                IntPtr address = mapddress + uopoffset + (IntPtr) (blocknum * mapblocksize);
 
                 if (address < endmapaddress)
                 {
                     realmapaddress = address;
                 }
 
-                ulong stidxaddress = staticidxaddress + (ulong) (block * staticidxblocksize);
+                IntPtr stidxaddress = staticidxaddress + (IntPtr) (block * staticidxblocksize);
                 StaidxBlock* bb = (StaidxBlock*) stidxaddress;
 
                 if (stidxaddress < endstaticidxaddress && bb->Size > 0 && bb->Position != 0xFFFFFFFF)
                 {
-                    ulong address1 = staticaddress + bb->Position;
+                    IntPtr address1 = staticaddress + (IntPtr)bb->Position;
 
                     if (address1 < endstaticaddress)
                     {
@@ -340,7 +340,7 @@ namespace ClassicUO.Assets
 
                     if (blockIndex < maxBlockCount)
                     {
-                        BlockData[blockIndex].MapAddress = (ulong) dif.PositionAddress;
+                        BlockData[blockIndex].MapAddress = dif.PositionAddress;
 
                         result = true;
                     }
@@ -359,7 +359,7 @@ namespace ClassicUO.Assets
                     return false;
                 }
 
-                ulong startAddress = (ulong) _staDif.StartAddress;
+                IntPtr startAddress = _staDif.StartAddress;
 
                 staticPatchesCount = Math.Min(staticPatchesCount, (int) difl.Length >> 2);
 
@@ -384,12 +384,12 @@ namespace ClassicUO.Assets
 
                     if (blockIndex < maxBlockCount)
                     {
-                        ulong realStaticAddress = 0;
+                        IntPtr realStaticAddress = 0;
                         int realStaticCount = 0;
 
                         if (sidx->Size > 0 && sidx->Position != 0xFFFF_FFFF)
                         {
-                            realStaticAddress = startAddress + sidx->Position;
+                            realStaticAddress = startAddress + (IntPtr)sidx->Position;
                             realStaticCount = (int) (sidx->Size / sizeOfStaicsBlock);
 
                             if (realStaticCount > 0)
@@ -709,11 +709,11 @@ namespace ClassicUO.Assets
 
     public struct IndexMap
     {
-        public ulong MapAddress;
-        public ulong OriginalMapAddress;
-        public ulong OriginalStaticAddress;
+        public IntPtr MapAddress;
+        public IntPtr OriginalMapAddress;
+        public IntPtr OriginalStaticAddress;
         public uint OriginalStaticCount;
-        public ulong StaticAddress;
+        public IntPtr StaticAddress;
         public uint StaticCount;
         public static IndexMap Invalid = new IndexMap();
 

--- a/src/ClassicUO.Assets/MultiLoader.cs
+++ b/src/ClassicUO.Assets/MultiLoader.cs
@@ -32,6 +32,7 @@
 
 using ClassicUO.IO;
 using ClassicUO.Utility;
+using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -56,7 +57,7 @@ namespace ClassicUO.Assets
         public static MultiLoader Instance => _instance ?? (_instance = new MultiLoader());
 
         public int Count { get; private set; }
-        private DataReader File;
+        private IDisposable File;
 
         public bool IsUOP { get; private set; }
         public int Offset { get; private set; }
@@ -86,14 +87,15 @@ namespace ClassicUO.Assets
 
                         if (System.IO.File.Exists(path) && System.IO.File.Exists(pathidx))
                         {
-                            File = new UOFile(path);
+                            var file = new UOFile(path);
 
                             using (var idxFile = new UOFile(pathidx))
                             {
-                                UOFileMul.FillEntries(File, idxFile, ref Entries);
+                                UOFileMul.FillEntries(file, idxFile, ref Entries);
                             }
 
                             Count = Offset = UOFileManager.Version >= ClientVersion.CV_7090 ? sizeof(MultiBlockNew) + 2 : sizeof(MultiBlock);
+                            File = file;
                         }
                     }
                 }

--- a/src/ClassicUO.Assets/MultiLoader.cs
+++ b/src/ClassicUO.Assets/MultiLoader.cs
@@ -47,6 +47,12 @@ namespace ClassicUO.Assets
         {
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            File?.Dispose();
+        }
+
         public static MultiLoader Instance => _instance ?? (_instance = new MultiLoader());
 
         public int Count { get; private set; }

--- a/src/ClassicUO.Assets/MultiMapLoader.cs
+++ b/src/ClassicUO.Assets/MultiMapLoader.cs
@@ -44,7 +44,7 @@ namespace ClassicUO.Assets
 {
     public sealed class FacetLoader : IDisposable
     {
-        private readonly DataReader file;
+        private readonly PinnedBuffer file;
 
         public bool HasData => file.HasData;
 
@@ -73,11 +73,11 @@ namespace ClassicUO.Assets
                 return default;
             }
 
-            file.Seek(0);
+            var reader = new DataReader(file);
 
-            int w = file.ReadShort();
+            int w = reader.ReadShort();
 
-            int h = file.ReadShort();
+            int h = reader.ReadShort();
 
             if (w < 1 || h < 1)
             {
@@ -99,13 +99,13 @@ namespace ClassicUO.Assets
             {
                 int x = 0;
 
-                int colorCount = file.ReadInt() / 3;
+                int colorCount = reader.ReadInt() / 3;
 
                 for (int i = 0; i < colorCount; i++)
                 {
-                    int size = file.ReadByte();
+                    int size = reader.ReadByte();
 
-                    uint color = HuesHelper.Color16To32(file.ReadUShort()) | 0xFF_00_00_00;
+                    uint color = HuesHelper.Color16To32(reader.ReadUShort()) | 0xFF_00_00_00;
 
                     for (int j = 0; j < size; j++)
                     {
@@ -132,7 +132,7 @@ namespace ClassicUO.Assets
     {
         private static MultiMapLoader _instance;
         private FacetLoader[] _facets = Array.Empty<FacetLoader>();
-        private DataReader _file;
+        private PinnedBuffer _file;
 
         private MultiMapLoader()
         {
@@ -202,10 +202,10 @@ namespace ClassicUO.Assets
                 return default;
             }
 
-            _file.Seek(0);
+            var reader = new DataReader(_file);
 
-            int w = _file.ReadInt();
-            int h = _file.ReadInt();
+            int w = reader.ReadInt();
+            int h = reader.ReadInt();
 
             if (w < 1 || h < 1)
             {
@@ -246,9 +246,9 @@ namespace ClassicUO.Assets
             int maxPixelValue = 1;
             int startHeight = starty * pheight;
 
-            while (_file.Position < _file.Length)
+            while (!reader.IsEOF)
             {
-                byte pic = _file.ReadByte();
+                byte pic = reader.ReadByte();
                 byte size = (byte) (pic & 0x7F);
                 bool colored = (pic & 0x80) != 0;
 

--- a/src/ClassicUO.Assets/SoundsLoader.cs
+++ b/src/ClassicUO.Assets/SoundsLoader.cs
@@ -377,6 +377,7 @@ namespace ClassicUO.Assets
         {
             base.Dispose(disposing);
             _musicData.Clear();
+            _file?.Dispose();
         }
     }
 }

--- a/src/ClassicUO.Assets/SoundsLoader.cs
+++ b/src/ClassicUO.Assets/SoundsLoader.cs
@@ -106,7 +106,7 @@ namespace ClassicUO.Assets
             {
                 int index = reader.ReadInt();
 
-                if (index < 0 || index >= MAX_SOUND_DATA_INDEX_COUNT || index >= _file.Length || Entries[index].Length != 0)
+                if (index < 0 || index >= MAX_SOUND_DATA_INDEX_COUNT || index >= Entries.Length || Entries[index].Length != 0)
                 {
                     continue;
                 }

--- a/src/ClassicUO.Assets/SoundsLoader.cs
+++ b/src/ClassicUO.Assets/SoundsLoader.cs
@@ -52,7 +52,7 @@ namespace ClassicUO.Assets
 
         public const int MAX_SOUND_DATA_INDEX_COUNT = 0xFFFF;
 
-        private DataReader _file;
+        private IDisposable _file;
 
         private bool entriesLoaded = false, musicLoaded = false;
 
@@ -81,12 +81,14 @@ namespace ClassicUO.Assets
 
                 if (File.Exists(path) && File.Exists(idxpath))
                 {
-                    _file = new UOFile(path);
+                    var file = new UOFile(path);
 
                     using (var idxFile = new UOFile(idxpath))
                     {
-                        UOFileMul.FillEntries(_file, idxFile, ref Entries);
+                        UOFileMul.FillEntries(file, idxFile, ref Entries);
                     }
+
+                    _file = file;
                 }
                 else
                 {

--- a/src/ClassicUO.Assets/SpeechesLoader.cs
+++ b/src/ClassicUO.Assets/SpeechesLoader.cs
@@ -71,18 +71,19 @@ namespace ClassicUO.Assets
                     }
 
                     using var file = new UOFile(path);
+                    var reader = new DataReader(file);
                     List<SpeechEntry> entries = new List<SpeechEntry>();
 
-                    while (file.Position < file.Length)
+                    while (!reader.IsEOF)
                     {
-                        int id = file.ReadUShortReversed();
-                        int length = file.ReadUShortReversed();
+                        int id = reader.ReadUShortReversed();
+                        int length = reader.ReadUShortReversed();
 
                         if (length > 0)
                         {
-                            entries.Add(new SpeechEntry(id, string.Intern(Encoding.UTF8.GetString((byte*) file.PositionAddress, length))));
+                            entries.Add(new SpeechEntry(id, string.Intern(Encoding.UTF8.GetString((byte*) reader.PositionAddress, length))));
 
-                            file.Skip(length);
+                            reader.Skip(length);
                         }
                     }
 

--- a/src/ClassicUO.Assets/TexmapsLoader.cs
+++ b/src/ClassicUO.Assets/TexmapsLoader.cs
@@ -41,7 +41,7 @@ namespace ClassicUO.Assets
     public class TexmapsLoader : UOFileLoader
     {
         private static TexmapsLoader _instance;
-        private DataReader _file;
+        private PinnedBuffer _file;
 
         public const int MAX_LAND_TEXTURES_DATA_INDEX_COUNT = 0x4000;
 

--- a/src/ClassicUO.Client/Game/Managers/AnimatedStaticsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AnimatedStaticsManager.cs
@@ -46,7 +46,7 @@ namespace ClassicUO.Game.Managers
 
         public unsafe void Initialize()
         {
-            DataReader file = AnimDataLoader.Instance.AnimDataFile;
+            PinnedBuffer file = AnimDataLoader.Instance.AnimDataFile;
 
             if (file == null)
             {
@@ -85,7 +85,7 @@ namespace ClassicUO.Game.Managers
                 return;
             }
 
-            DataReader file = AnimDataLoader.Instance.AnimDataFile;
+            PinnedBuffer file = AnimDataLoader.Instance.AnimDataFile;
 
             if (file == null)
             {

--- a/src/ClassicUO.IO/DataReader.cs
+++ b/src/ClassicUO.IO/DataReader.cs
@@ -40,45 +40,13 @@ namespace ClassicUO.IO
     /// <summary>
     ///     A fast Little Endian data reader.
     /// </summary>
-    public unsafe class DataReader : IDisposable
+    public unsafe class DataReader : PinnedBuffer
     {
-        private byte* _data;
-
-        public bool HasData => _data != null;
-
         public long Position { get; set; }
 
-        public long Length { get; private set; }
-
-        public IntPtr StartAddress => (IntPtr) _data;
-        public IntPtr EndAddress => StartAddress + (IntPtr)Length;
-
-        public IntPtr PositionAddress => (IntPtr) (_data + Position);
+        public IntPtr PositionAddress => (IntPtr) (StartAddress + Position);
 
         public bool IsEOF => Position >= Length;
-
-        ~DataReader()
-        {
-            Dispose(false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void SetData(byte* data, long length)
-        {
-            _data = data;
-            Length = length;
-            Position = 0;
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Seek(long idx)
@@ -106,7 +74,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(1);
 
-            return _data[Position++];
+            return Data[Position++];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -126,7 +94,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(2);
 
-            short v = *(short*) (_data + Position);
+            short v = *(short*)PositionAddress;
             Position += 2;
 
             return v;
@@ -137,7 +105,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(2);
 
-            ushort v = *(ushort*) (_data + Position);
+            ushort v = *(ushort*)PositionAddress;
             Position += 2;
 
             return v;
@@ -148,7 +116,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(4);
 
-            int v = *(int*) (_data + Position);
+            int v = *(int*)PositionAddress;
 
             Position += 4;
 
@@ -160,7 +128,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(4);
 
-            uint v = *(uint*) (_data + Position);
+            uint v = *(uint*)PositionAddress;
             Position += 4;
 
             return v;
@@ -171,7 +139,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(8);
 
-            long v = *(long*) (_data + Position);
+            long v = *(long*)PositionAddress;
             Position += 8;
 
             return v;
@@ -182,7 +150,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(8);
 
-            ulong v = *(ulong*) (_data + Position);
+            ulong v = *(ulong*)PositionAddress;
             Position += 8;
 
             return v;

--- a/src/ClassicUO.IO/DataReader.cs
+++ b/src/ClassicUO.IO/DataReader.cs
@@ -212,47 +212,6 @@ namespace ClassicUO.IO
             return v;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public byte[] ReadArray(int count)
-        {
-            EnsureSize(count);
-
-            byte[] data = new byte[count];
-
-            fixed (byte* ptr = data)
-            {
-                Buffer.MemoryCopy(&_data[Position], ptr, count, count);
-            }
-
-            Position += count;
-
-            return data;
-        }
-
-        public string ReadASCII(int size)
-        {
-            EnsureSize(size);
-
-            Span<char> span = stackalloc char[size];
-            ValueStringBuilder sb = new ValueStringBuilder(span);
-
-            for (int i = 0; i < size; i++)
-            {
-                char c = (char)ReadByte();
-
-                if (c != 0)
-                {
-                    sb.Append(c);
-                }
-            }
-
-            string ss = sb.ToString();
-
-            sb.Dispose();
-
-            return ss;
-        }
-
         [Conditional("DEBUG")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void EnsureSize(int size)

--- a/src/ClassicUO.IO/DataReader.cs
+++ b/src/ClassicUO.IO/DataReader.cs
@@ -40,13 +40,20 @@ namespace ClassicUO.IO
     /// <summary>
     ///     A fast Little Endian data reader.
     /// </summary>
-    public unsafe class DataReader : PinnedBuffer
+    public sealed unsafe class DataReader
     {
+        private readonly PinnedBuffer buffer;
+
         public long Position { get; set; }
 
-        public IntPtr PositionAddress => (IntPtr) (StartAddress + Position);
+        public IntPtr PositionAddress => (IntPtr) (buffer.StartAddress + Position);
 
-        public bool IsEOF => Position >= Length;
+        public bool IsEOF => Position >= buffer.Length;
+
+        public DataReader(PinnedBuffer _buffer)
+        {
+            buffer = _buffer;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Seek(long idx)
@@ -74,7 +81,7 @@ namespace ClassicUO.IO
         {
             EnsureSize(1);
 
-            return Data[Position++];
+            return buffer.Data[Position++];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -160,7 +167,7 @@ namespace ClassicUO.IO
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void EnsureSize(int size)
         {
-            if (Position + size > Length)
+            if (Position + size > buffer.Length)
             {
 #if DEBUG
                 throw new IndexOutOfRangeException();

--- a/src/ClassicUO.IO/DataReader.cs
+++ b/src/ClassicUO.IO/DataReader.cs
@@ -34,7 +34,6 @@ using ClassicUO.Utility;
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace ClassicUO.IO
 {
@@ -44,7 +43,6 @@ namespace ClassicUO.IO
     public unsafe class DataReader : IDisposable
     {
         private byte* _data;
-        private GCHandle _handle;
 
         public bool HasData => _data != null;
 
@@ -72,34 +70,12 @@ namespace ClassicUO.IO
 
         protected virtual void Dispose(bool disposing)
         {
-            ReleaseData();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ReleaseData()
-        {
-            if (_handle.IsAllocated)
-            {
-                _handle.Free();
-            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void SetData(byte* data, long length)
         {
-            ReleaseData();
-
             _data = data;
-            Length = length;
-            Position = 0;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void SetData(byte[] data, long length)
-        {
-            ReleaseData();
-            _handle = GCHandle.Alloc(data, GCHandleType.Pinned);
-            _data = (byte*) _handle.AddrOfPinnedObject();
             Length = length;
             Position = 0;
         }

--- a/src/ClassicUO.IO/DataReader.cs
+++ b/src/ClassicUO.IO/DataReader.cs
@@ -97,8 +97,6 @@ namespace ClassicUO.IO
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void SetData(byte[] data, long length)
         {
-            //fixed (byte* d = data)
-            //    SetData(d, length);
             ReleaseData();
             _handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             _data = (byte*) _handle.AddrOfPinnedObject();

--- a/src/ClassicUO.IO/PinnedBuffer.cs
+++ b/src/ClassicUO.IO/PinnedBuffer.cs
@@ -1,0 +1,46 @@
+﻿// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ClassicUO.IO;
+
+/// <summary>
+///     A buffer with a fixed address, i.e. the allocation is pinned.
+/// </summary>
+public unsafe class PinnedBuffer : IDisposable
+{
+    private byte* _data;
+
+    public bool HasData => _data != null;
+
+    public long Length { get; private set; }
+
+    public byte *Data => _data;
+    public IntPtr StartAddress => (IntPtr) _data;
+    public IntPtr EndAddress => StartAddress + (IntPtr)Length;
+
+    ~PinnedBuffer()
+    {
+        Dispose(false);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void SetData(byte* data, long length)
+    {
+        _data = data;
+        Length = length;
+    }
+}

--- a/src/ClassicUO.IO/UOFile.cs
+++ b/src/ClassicUO.IO/UOFile.cs
@@ -37,7 +37,7 @@ using System.IO.MemoryMappedFiles;
 
 namespace ClassicUO.IO
 {
-    public class UOFile : DataReader
+    public class UOFile : PinnedBuffer
     {
         public UOFile(string filepath)
         {

--- a/src/ClassicUO.IO/UOFileIndex.cs
+++ b/src/ClassicUO.IO/UOFileIndex.cs
@@ -70,6 +70,9 @@ namespace ClassicUO.IO
         public ushort Hue;
         public sbyte AnimOffset;
 
+        public IntPtr StartAddress => FileAddress + (IntPtr)Offset;
+        public IntPtr EndAddress => StartAddress + (IntPtr)Length;
+
         public bool IsValid()
         {
             return Offset >= 0 && Length > 0 && Offset != 0x0000_0000_FFFF_FFFF;

--- a/src/ClassicUO.IO/UOFileIndex.cs
+++ b/src/ClassicUO.IO/UOFileIndex.cs
@@ -48,7 +48,7 @@ namespace ClassicUO.IO
             ushort hue = 0
         )
         {
-            Address = address;
+            FileAddress = address;
             FileSize = fileSize;
             Offset = offset;
             Length = length;
@@ -60,7 +60,7 @@ namespace ClassicUO.IO
             AnimOffset = 0;
         }
 
-        public IntPtr Address;
+        public IntPtr FileAddress;
         public uint FileSize;
         public long Offset;
         public int Length;
@@ -89,10 +89,10 @@ namespace ClassicUO.IO
          */
         public bool IsInvalid()
         {
-            return Address == IntPtr.Zero;
+            return FileAddress == IntPtr.Zero;
         }
 
-        public unsafe byte* Data => (byte *)(Address + Offset);
+        public unsafe byte* Data => (byte *)(FileAddress + Offset);
     }
 
     public struct UOFileIndex5D

--- a/src/ClassicUO.IO/UOFileMul.cs
+++ b/src/ClassicUO.IO/UOFileMul.cs
@@ -45,7 +45,7 @@ namespace ClassicUO.IO
             public uint Size;
         };
 
-        public static unsafe void FillEntries(DataReader dataFile, DataReader idxFile, ref UOFileIndex[] entries)
+        public static unsafe void FillEntries(PinnedBuffer dataFile, PinnedBuffer idxFile, ref UOFileIndex[] entries)
         {
             int count = (int) idxFile.Length / 12;
             entries = new UOFileIndex[count];

--- a/src/ClassicUO.IO/UOFileMul.cs
+++ b/src/ClassicUO.IO/UOFileMul.cs
@@ -55,7 +55,7 @@ namespace ClassicUO.IO
             for (int i = 0; i < count; i++, idxPtr++)
             {
                 ref UOFileIndex e = ref entries[i];
-                e.Address = dataFile.StartAddress;   // .mul mmf address
+                e.FileAddress = dataFile.StartAddress;   // .mul mmf address
                 e.FileSize = (uint) dataFile.Length; // .mul mmf length
                 e.Offset = idxPtr->Offset; // .idx offset
                 e.Length = idxPtr->Length;  // .idx length

--- a/src/ClassicUO.IO/UOFileUop.cs
+++ b/src/ClassicUO.IO/UOFileUop.cs
@@ -56,39 +56,40 @@ namespace ClassicUO.IO
         
         private void Load()
         {
-            Seek(0);
+            var reader = new DataReader(this);
+            reader.Seek(0);
 
-            if (ReadUInt() != UOP_MAGIC_NUMBER)
+            if (reader.ReadUInt() != UOP_MAGIC_NUMBER)
             {
                 throw new ArgumentException("Bad uop file");
             }
 
-            uint version = ReadUInt();
-            uint format_timestamp = ReadUInt();
-            long nextBlock = ReadLong();
-            uint block_size = ReadUInt();
-            int count = ReadInt();
+            uint version = reader.ReadUInt();
+            uint format_timestamp = reader.ReadUInt();
+            long nextBlock = reader.ReadLong();
+            uint block_size = reader.ReadUInt();
+            int count = reader.ReadInt();
 
 
-            Seek(nextBlock);
+            reader.Seek(nextBlock);
             int total = 0;
             int real_total = 0;
 
             do
             {
-                int filesCount = ReadInt();
-                nextBlock = ReadLong();
+                int filesCount = reader.ReadInt();
+                nextBlock = reader.ReadLong();
                 total += filesCount;
 
                 for (int i = 0; i < filesCount; i++)
                 {
-                    long offset = ReadLong();
-                    int headerLength = ReadInt();
-                    int compressedLength = ReadInt();
-                    int decompressedLength = ReadInt();
-                    ulong hash = ReadULong();
-                    uint data_hash = ReadUInt();
-                    short flag = ReadShort();
+                    long offset = reader.ReadLong();
+                    int headerLength = reader.ReadInt();
+                    int compressedLength = reader.ReadInt();
+                    int decompressedLength = reader.ReadInt();
+                    ulong hash = reader.ReadULong();
+                    uint data_hash = reader.ReadUInt();
+                    short flag = reader.ReadShort();
                     int length = flag == 1 ? compressedLength : decompressedLength;
 
                     if (offset == 0)
@@ -101,10 +102,10 @@ namespace ClassicUO.IO
 
                     if (_hasExtra)
                     {
-                        long curpos = Position;
-                        Seek(offset);
-                        short extra1 = (short) ReadInt();
-                        short extra2 = (short) ReadInt();
+                        long curpos = reader.Position;
+                        reader.Seek(offset);
+                        short extra1 = (short) reader.ReadInt();
+                        short extra2 = (short) reader.ReadInt();
 
                         _hashes.Add
                         (
@@ -121,7 +122,7 @@ namespace ClassicUO.IO
                             )
                         );
 
-                        Seek(curpos);
+                        reader.Seek(curpos);
                     }
                     else
                     {
@@ -140,7 +141,7 @@ namespace ClassicUO.IO
                     }
                 }
 
-                Seek(nextBlock);
+                reader.Seek(nextBlock);
             } while (nextBlock != 0);
 
             TotalEntriesCount = real_total;


### PR DESCRIPTION
Replace lots of DataReader calls with direct pointer accesses, move its core feature to the new class PinnedBuffer, then remove DataReader from the class tree, converting it to a wrapper class.