### PR TITLE
Assets: add compile-time options to disable the UOP and mapdif code

### DIFF
--- a/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -53,20 +53,28 @@ namespace ClassicUO.Assets
         [ThreadStatic]
         private static FrameInfo[] _frames;
 
+#if ENABLE_UOP
         [ThreadStatic]
         private static byte[] _decompressedData;
+#endif
 
         private readonly bool[] filesLoaded = new bool[5];
         private readonly PinnedBuffer[] _files = new PinnedBuffer[5];
         private readonly PinnedBuffer[] _filesIdx = new PinnedBuffer[5];
+
+#if ENABLE_UOP
         private readonly UOFileUop[] _filesUop = new UOFileUop[4];
+#endif
 
         private readonly Dictionary<ushort, Dictionary<ushort, EquipConvData>> _equipConv = new Dictionary<ushort, Dictionary<ushort, EquipConvData>>();
         private readonly Dictionary<int, MobTypeInfo> _mobTypes = new Dictionary<int, MobTypeInfo>();
         private readonly Dictionary<int, BodyInfo> _bodyInfos = new Dictionary<int, BodyInfo>();
         private readonly Dictionary<int, BodyInfo> _corpseInfos = new Dictionary<int, BodyInfo>();
         private readonly Dictionary<int, BodyConvInfo> _bodyConvInfos = new Dictionary<int, BodyConvInfo>();
+
+#if ENABLE_UOP
         private readonly Dictionary<int, UopInfo> _uopInfos = new Dictionary<int, UopInfo>();
+#endif
 
         private AnimationsLoader() { }
 
@@ -76,8 +84,10 @@ namespace ClassicUO.Assets
                 i?.Dispose();
             foreach (var i in _filesIdx)
                 i?.Dispose();
+#if ENABLE_UOP
             foreach (var i in _filesUop)
                 i?.Dispose();
+#endif
         }
 
         public static AnimationsLoader Instance =>
@@ -133,6 +143,7 @@ namespace ClassicUO.Assets
 
         private unsafe void LoadInternal()
         {
+#if ENABLE_UOP
             bool loaduop = false;
             int[] un = { 0x40000, 0x10000, 0x20000, 0x20000, 0x20000 };
 
@@ -161,6 +172,7 @@ namespace ClassicUO.Assets
             {
                 LoadUop();
             }
+#endif // ENABLE_UOP
 
             string path = UOFileManager.GetUOFilePath("mobtypes.txt");
 
@@ -304,6 +316,7 @@ namespace ClassicUO.Assets
             return false;
         }
 
+#if ENABLE_UOP
         public bool ReplaceUopGroup(ushort body, ref byte group)
         {
             if (_uopInfos.TryGetValue(body, out var uopInfo))
@@ -315,6 +328,7 @@ namespace ClassicUO.Assets
 
             return false;
         }
+#endif // ENABLE_UOP
 
         public unsafe ReadOnlySpan<AnimIdxBlock> GetIndices
         (
@@ -339,6 +353,7 @@ namespace ClassicUO.Assets
 
             flags = mobInfo.Flags;
 
+#if ENABLE_UOP
             if (mobInfo.Flags.HasFlag(AnimationFlags.UseUopAnimation))
             {
                 if (animType == AnimationGroupsType.Unknown)
@@ -375,6 +390,7 @@ namespace ClassicUO.Assets
 
                 return animIndices;
             }
+#endif // ENABLE_UOP
 
             if (_bodyConvInfos.TryGetValue(body, out var bodyConvInfo))
             {
@@ -720,6 +736,7 @@ namespace ClassicUO.Assets
             }
         }
 
+#if ENABLE_UOP
         private unsafe void LoadUop()
         {
             if (UOFileManager.Version <= ClientVersion.CV_60144)
@@ -925,6 +942,7 @@ namespace ClassicUO.Assets
                 }
             }
         }
+#endif // ENABLE_UOP
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe uint CalculatePeopleGroupOffset(ushort graphic)
@@ -1223,10 +1241,12 @@ namespace ClassicUO.Assets
                         return 2;
                     }
 
+#if ENABLE_UOP
                     if ((animFlags & AnimationFlags.UseUopAnimation) != 0)
                     {
                         return (byte)(second ? 3 : 2);
                     }
+#endif // ENABLE_UOP
 
                     return (byte)(
                         second ? LowAnimationGroup.Die2 : LowAnimationGroup.Die1
@@ -1244,10 +1264,12 @@ namespace ClassicUO.Assets
 
                 case AnimationGroupsType.Monster:
 
+#if ENABLE_UOP
                     if ((animFlags & AnimationFlags.UseUopAnimation) != 0)
                     {
                         return (byte)(second ? 3 : 2);
                     }
+#endif // ENABLE_UOP
 
                     return (byte)(
                         second ? HighAnimationGroup.Die2 : HighAnimationGroup.Die1
@@ -1263,6 +1285,7 @@ namespace ClassicUO.Assets
             return 0;
         }
 
+#if ENABLE_UOP
         public unsafe Span<FrameInfo> ReadUOPAnimationFrames(
             ushort animID,
             byte animGroup,
@@ -1415,6 +1438,7 @@ namespace ClassicUO.Assets
 
             return frames;
         }
+#endif // ENABLE_UOP
 
         public unsafe Span<FrameInfo> ReadMULAnimationFrames(int fileIndex, AnimIdxBlock index)
         {
@@ -1601,6 +1625,7 @@ namespace ClassicUO.Assets
             public uint Unknown;
         }
 
+#if ENABLE_UOP
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         ref struct UOPAnimationHeader
         {
@@ -1614,6 +1639,7 @@ namespace ClassicUO.Assets
 
             public uint DataOffset;
         }
+#endif // ENABLE_UOP
     }
 
     public enum AnimationGroups
@@ -1739,7 +1765,9 @@ namespace ClassicUO.Assets
         Unknown2000 = 0x02000,
         Unknown4000 = 0x04000,
         Unknown8000 = 0x08000,
+#if ENABLE_UOP
         UseUopAnimation = 0x10000,
+#endif
         Unknown20000 = 0x20000,
         Unknown40000 = 0x40000,
         Unknown80000 = 0x80000,
@@ -1796,6 +1824,7 @@ namespace ClassicUO.Assets
         public sbyte MountHeight;
     }
 
+#if ENABLE_UOP
     unsafe struct UopInfo
     {
         private fixed int _replacedAnim[AnimationsLoader.MAX_ACTIONS];
@@ -1814,6 +1843,7 @@ namespace ClassicUO.Assets
 
         public sbyte HeightOffset;
     }
+#endif // ENABLE_UOP
 
     [Flags]
     public enum BodyConvFlags

--- a/src/ClassicUO.Assets/ArtLoader.cs
+++ b/src/ClassicUO.Assets/ArtLoader.cs
@@ -68,7 +68,9 @@ namespace ClassicUO.Assets
         {
             return Task.Run(() =>
             {
-                string filePath = UOFileManager.GetUOFilePath("artLegacyMUL.uop");
+                string filePath;
+#if ENABLE_UOP
+                filePath = UOFileManager.GetUOFilePath("artLegacyMUL.uop");
 
                 if (UOFileManager.IsUOPInstallation && File.Exists(filePath))
                 {
@@ -81,6 +83,7 @@ namespace ClassicUO.Assets
                     _file = file;
                 }
                 else
+#endif // ENABLE_UOP
                 {
                     filePath = UOFileManager.GetUOFilePath("art.mul");
                     string idxPath = UOFileManager.GetUOFilePath("artidx.mul");

--- a/src/ClassicUO.Assets/ArtLoader.cs
+++ b/src/ClassicUO.Assets/ArtLoader.cs
@@ -43,7 +43,6 @@ namespace ClassicUO.Assets
     {
         private static ArtLoader _instance;
         private IDisposable _file;
-        private readonly ushort _graphicMask;
 
         [ThreadStatic]
         private static uint[] _data = null;
@@ -53,7 +52,6 @@ namespace ClassicUO.Assets
 
         private ArtLoader(int staticCount, int landCount)
         {
-            _graphicMask = UOFileManager.IsUOPInstallation ? (ushort)0xFFFF : (ushort)0x3FFF;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/ClassicUO.Assets/GumpsLoader.cs
+++ b/src/ClassicUO.Assets/GumpsLoader.cs
@@ -57,13 +57,19 @@ namespace ClassicUO.Assets
         public static GumpsLoader Instance =>
             _instance ?? (_instance = new GumpsLoader(MAX_GUMP_DATA_INDEX_COUNT));
 
+#if ENABLE_UOP
         public bool UseUOPGumps = false;
+#else
+        public bool UseUOPGumps => false;
+#endif
 
         public Task Load()
         {
             return Task.Run(() =>
             {
-                string path = UOFileManager.GetUOFilePath("gumpartLegacyMUL.uop");
+                string path;
+#if ENABLE_UOP
+                path = UOFileManager.GetUOFilePath("gumpartLegacyMUL.uop");
 
                 if (UOFileManager.IsUOPInstallation && File.Exists(path))
                 {
@@ -77,6 +83,7 @@ namespace ClassicUO.Assets
                     UseUOPGumps = true;
                 }
                 else
+#endif // ENABLE_UOP
                 {
                     path = UOFileManager.GetUOFilePath("gumpart.mul");
                     string pathidx = UOFileManager.GetUOFilePath("gumpidx.mul");
@@ -98,7 +105,9 @@ namespace ClassicUO.Assets
                         UOFileMul.FillEntries(file, idxFile, ref Entries);
                     }
 
+#if ENABLE_UOP
                     UseUOPGumps = false;
+#endif
                     _file = file;
                 }
 

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -53,7 +53,9 @@ namespace ClassicUO.Assets
         private PinnedBuffer _fileStatics;
         private PinnedBuffer _fileIdxStatics;
 
+#if ENABLE_UOP
         private readonly bool isuop;
+#endif
 
         private PinnedBuffer _mapDif;
         private PinnedBuffer _staDif;
@@ -87,7 +89,9 @@ namespace ClassicUO.Assets
             idx = i;
             inherit = _inherit;
 
-            string path = UOFileManager.GetUOFilePath($"map{i}LegacyMUL.uop");
+            string path;
+#if ENABLE_UOP
+            path = UOFileManager.GetUOFilePath($"map{i}LegacyMUL.uop");
 
             if (UOFileManager.IsUOPInstallation && File.Exists(path))
             {
@@ -95,6 +99,7 @@ namespace ClassicUO.Assets
                 mapFileInfo = new FileInfo(path);
             }
             else
+#endif // ENABLE_UOP
             {
                 path = UOFileManager.GetUOFilePath($"map{i}.mul");
                 mapFileInfo = new FileInfo(path);
@@ -120,11 +125,13 @@ namespace ClassicUO.Assets
         {
             string path = mapFileInfo.ToString();
 
+#if ENABLE_UOP
             if (isuop)
             {
                 _fileMap = new UOFileUop(path, $"build/map{i}legacymul/{{0:D8}}.dat");
             }
             else
+#endif // ENABLE_UOP
             {
                 if (mapFileInfo.Exists)
                 {
@@ -208,7 +215,9 @@ namespace ClassicUO.Assets
             IntPtr mapddress = file.StartAddress;
             IntPtr endmapaddress = mapddress + (IntPtr) file.Length;
             IntPtr uopoffset = 0;
+#if ENABLE_UOP
             int fileNumber = -1;
+#endif
 
             for (int block = 0; block < maxblockcount; block++)
             {
@@ -216,6 +225,7 @@ namespace ClassicUO.Assets
                 uint realstaticcount = 0;
                 int blocknum = block;
 
+#if ENABLE_UOP
                 if (isuop)
                 {
                     blocknum &= 4095;
@@ -237,6 +247,7 @@ namespace ClassicUO.Assets
                         }
                     }
                 }
+#endif // ENABLE_UOP
 
                 IntPtr address = mapddress + uopoffset + (IntPtr) (blocknum * mapblocksize);
 
@@ -273,10 +284,12 @@ namespace ClassicUO.Assets
                 data.OriginalStaticCount = realstaticcount;
             }
 
+#if ENABLE_UOP
             if (isuop)
             {
                 ((UOFileUop)file)?.ClearHashes();
             }
+#endif // ENABLE_UOP
         }
 
         public void EnsureLoaded()
@@ -424,6 +437,10 @@ namespace ClassicUO.Assets
             {
                 return;
             }
+
+#if !ENABLE_UOP
+            bool isuop = false;
+#endif
 
             if (!isuop && _fileMap != null && _fileMap.HasData &&
                 _fileIdxStatics != null && _fileIdxStatics.HasData &&

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -57,8 +57,10 @@ namespace ClassicUO.Assets
         private readonly bool isuop;
 #endif
 
+#if ENABLE_MAPDIF
         private PinnedBuffer _mapDif;
         private PinnedBuffer _staDif;
+#endif // ENABLE_MAPDIF
 
         public int Width { get; private set; }
         public int Height { get; private set; }
@@ -82,7 +84,9 @@ namespace ClassicUO.Assets
 
         private bool isOpened = false, isLoaded = false;
 
+#if ENABLE_MAPDIF
         private int MapPatchesCountPostponed = 0, StaticPatchesCountPostponed = 0;
+#endif
 
         public OneMapLoader(int i, OneMapLoader _inherit)
         {
@@ -111,8 +115,10 @@ namespace ClassicUO.Assets
             _fileMap?.Dispose();
             _fileStatics?.Dispose();
             _fileIdxStatics?.Dispose();
+#if ENABLE_MAPDIF
             _mapDif?.Dispose();
             _staDif?.Dispose();
+#endif
         }
 
         public void SetSize(int width, int height)
@@ -138,6 +144,7 @@ namespace ClassicUO.Assets
                     _fileMap = new UOFile(path);
                 }
 
+#if ENABLE_MAPDIF
                 path = UOFileManager.GetUOFilePath($"mapdif{i}.mul");
                 if (File.Exists(path))
                 {
@@ -149,6 +156,7 @@ namespace ClassicUO.Assets
                 {
                     _staDif = new UOFile(path);
                 }
+#endif // ENABLE_MAPDIF
             }
 
             path = UOFileManager.GetUOFilePath($"statics{i}.mul");
@@ -304,6 +312,7 @@ namespace ClassicUO.Assets
             isLoaded = true;
             Load();
 
+#if ENABLE_MAPDIF
             if (MapPatchesCountPostponed >= 0 && StaticPatchesCountPostponed >= 0)
             {
                 /* ApplyPatches() was called before the map was loaded */
@@ -311,8 +320,10 @@ namespace ClassicUO.Assets
                 MapPatchesCountPostponed = 0;
                 StaticPatchesCountPostponed = 0;
             }
+#endif // ENABLE_MAPDIF
         }
 
+#if ENABLE_MAPDIF
         public unsafe bool DoApplyPatches(int mapPatchesCount, int staticPatchesCount)
         {
             ResetPatchesInBlockTable();
@@ -409,9 +420,11 @@ namespace ClassicUO.Assets
 
             return result;
         }
+#endif // ENABLE_MAPDIF
 
         public bool ApplyPatches(int mapPatchesCount, int staticPatchesCount)
         {
+#if ENABLE_MAPDIF
             if (!isLoaded)
             {
                 /* the map is not yet loaded; postpone the operation
@@ -422,6 +435,9 @@ namespace ClassicUO.Assets
             }
 
             return DoApplyPatches(mapPatchesCount, staticPatchesCount);
+#else
+            return false;
+#endif
         }
 
         private void ResetPatchesInBlockTable()

--- a/src/ClassicUO.Assets/MultiLoader.cs
+++ b/src/ClassicUO.Assets/MultiLoader.cs
@@ -59,7 +59,9 @@ namespace ClassicUO.Assets
         public int Count { get; private set; }
         private IDisposable File;
 
+#if ENABLE_UOP
         public bool IsUOP { get; private set; }
+#endif // ENABLE_UOP
         public int Offset { get; private set; }
 
 
@@ -69,6 +71,7 @@ namespace ClassicUO.Assets
             (
                 () =>
                 {
+#if ENABLE_UOP
                     string uopPath = UOFileManager.GetUOFilePath("MultiCollection.uop");
 
                     if (UOFileManager.IsUOPInstallation && System.IO.File.Exists(uopPath))
@@ -81,6 +84,7 @@ namespace ClassicUO.Assets
                         IsUOP = true;
                     }
                     else
+#endif // ENABLE_UOP
                     {
                         string path = UOFileManager.GetUOFilePath("multi.mul");
                         string pathidx = UOFileManager.GetUOFilePath("multi.idx");

--- a/src/ClassicUO.Assets/SoundsLoader.cs
+++ b/src/ClassicUO.Assets/SoundsLoader.cs
@@ -64,7 +64,10 @@ namespace ClassicUO.Assets
 
         private void LoadFileEntries()
         {
-            string path = UOFileManager.GetUOFilePath("soundLegacyMUL.uop");
+            string path;
+
+#if ENABLE_UOP
+            path = UOFileManager.GetUOFilePath("soundLegacyMUL.uop");
 
             if (UOFileManager.IsUOPInstallation && File.Exists(path))
             {
@@ -75,6 +78,7 @@ namespace ClassicUO.Assets
                 _file = file;
             }
             else
+#endif // ENABLE_UOP
             {
                 path = UOFileManager.GetUOFilePath("sound.mul");
                 string idxpath = UOFileManager.GetUOFilePath("soundidx.mul");

--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -84,7 +84,9 @@ namespace ClassicUO.Assets
 
         public static ClientVersion Version;
         public static string BasePath = "";
+#if ENABLE_UOP
         public static bool IsUOPInstallation;
+#endif
 
         public static void Load(ClientVersion version, string basePath, string lang)
         {
@@ -95,7 +97,9 @@ namespace ClassicUO.Assets
 
             UOFilesOverrideMap.Instance.Load(); // need to load this first so that it manages can perform the file overrides if needed
 
+#if ENABLE_UOP
             IsUOPInstallation = Version >= ClientVersion.CV_7000 && File.Exists(GetUOFilePath("MainMisc.uop"));
+#endif
 
             List<Task> tasks = new List<Task>
             {

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -265,6 +265,7 @@ namespace ClassicUO.Game.GameObjects
             ref UOFileIndex entry = ref MultiLoader.Instance.GetValidRefEntry(Graphic);
             bool movable = false;
 
+#if ENABLE_UOP
             if (MultiLoader.Instance.IsUOP)
             {
                 if (entry.Length > 0 && entry.DecompressedLength > 0)
@@ -379,6 +380,7 @@ namespace ClassicUO.Game.GameObjects
                 }
             }
             else
+#endif // ENABLE_UOP
             {
                 byte *src = entry.Data;
                 int count = entry.Length / MultiLoader.Instance.Offset;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -468,6 +468,7 @@ namespace ClassicUO.Game.GameObjects
                     return;
                 }
 
+#if ENABLE_UOP
                 if ((flags & AnimationFlags.UseUopAnimation) != 0)
                 {
                     if (animGroup != AnimationGroups.People)
@@ -498,6 +499,7 @@ namespace ClassicUO.Game.GameObjects
                         return;
                     }
                 }
+#endif // ENABLE_UOP
 
                 int first_value = RandomHelper.GetValue(0, 2);
 

--- a/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
@@ -174,6 +174,7 @@ namespace ClassicUO.Game.GameObjects
                         }
                         else
                         {
+#if ENABLE_UOP
                             if (
                                 (flags & AnimationFlags.UseUopAnimation) != 0
                                 && !mobile.InWarMode
@@ -182,6 +183,7 @@ namespace ClassicUO.Game.GameObjects
                                 result = 25;
                             }
                             else
+#endif // ENABLE_UOP
                             {
                                 result = 1;
                             }
@@ -199,11 +201,13 @@ namespace ClassicUO.Game.GameObjects
                     }
                     else
                     {
+#if ENABLE_UOP
                         if ((flags & AnimationFlags.UseUopAnimation) != 0)
                         {
                             result = 24;
                         }
                         else
+#endif // ENABLE_UOP
                         {
                             result = 0;
                         }
@@ -211,11 +215,13 @@ namespace ClassicUO.Game.GameObjects
                 }
                 else
                 {
+#if ENABLE_UOP
                     if ((flags & AnimationFlags.UseUopAnimation) != 0 && !mobile.InWarMode)
                     {
                         result = 22;
                     }
                     else
+#endif // ENABLE_UOP
                     {
                         result = 0;
                     }
@@ -570,7 +576,9 @@ namespace ClassicUO.Game.GameObjects
             AnimationGroupsType type = Client.Game.UO.Animations.GetAnimType(graphic);
             AnimationFlags  flags = Client.Game.UO.Animations.GetAnimFlags(graphic);
 
+#if ENABLE_UOP
             bool uop = (flags & AnimationFlags.UseUopAnimation) != 0;
+#endif
 
             if (mobile.AnimationFromServer && mobile._animationGroup != 0xFF)
             {
@@ -707,11 +715,14 @@ namespace ClassicUO.Game.GameObjects
                         v13 = 1;
                     }
 
+#if ENABLE_UOP
                     if ((flags & AnimationFlags.UseUopAnimation) != 0)
                     {
                         // do nothing?
                     }
-                    else if (v13 > 21)
+                    else
+#endif // ENABLE_UOP
+                        if (v13 > 21)
                     {
                         v13 = 1;
                     }
@@ -1078,6 +1089,7 @@ namespace ClassicUO.Game.GameObjects
                         {
                             if (result == 0xFF)
                             {
+#if ENABLE_UOP
                                 if ((flags & AnimationFlags.UseUopAnimation) != 0)
                                 {
                                     if (
@@ -1093,6 +1105,7 @@ namespace ClassicUO.Game.GameObjects
                                     }
                                 }
                                 else
+#endif // ENABLE_UOP
                                 {
                                     result = 2;
                                 }
@@ -1100,17 +1113,20 @@ namespace ClassicUO.Game.GameObjects
                         }
                         else if (isRun)
                         {
+#if ENABLE_UOP
                             if ((flags & AnimationFlags.UseUopAnimation) != 0)
                             {
                                 result = 24;
                             }
                             else
+#endif // ENABLE_UOP
                             {
                                 result = Client.Game.UO.Animations.AnimationExists(graphic, 1)
                                     ? (byte)1
                                     : (byte)2;
                             }
                         }
+#if ENABLE_UOP
                         else if (
                             (flags & AnimationFlags.UseUopAnimation) != 0
                             && (
@@ -1121,6 +1137,7 @@ namespace ClassicUO.Game.GameObjects
                         {
                             result = 22;
                         }
+#endif // ENABLE_UOP
                         else
                         {
                             result = 0;
@@ -1198,6 +1215,7 @@ namespace ClassicUO.Game.GameObjects
                                 }
                                 else
                                 {
+#if ENABLE_UOP
                                     if (
                                         uop
                                         && type == AnimationGroupsType.Equipment
@@ -1207,6 +1225,7 @@ namespace ClassicUO.Game.GameObjects
                                         result = 37;
                                     }
                                     else
+#endif // ENABLE_UOP
                                     {
                                         result = 4;
                                     }
@@ -1239,6 +1258,7 @@ namespace ClassicUO.Game.GameObjects
                                     {
                                         if (hand2 != null)
                                         {
+#if ENABLE_UOP
                                             if (
                                                 uop
                                                 && type == AnimationGroupsType.Equipment
@@ -1251,6 +1271,7 @@ namespace ClassicUO.Game.GameObjects
                                                 result = 8;
                                             }
                                             else
+#endif // ENABLE_UOP
                                             {
                                                 result = 7;
                                             }
@@ -1313,6 +1334,7 @@ namespace ClassicUO.Game.GameObjects
                     //}
                     else if (isRun || !mobile.InWarMode || mobile.IsDead)
                     {
+#if ENABLE_UOP
                         if ((flags & AnimationFlags.UseUopAnimation) != 0)
                         {
                             // i'm not sure here if it's necessary the isgargoyle
@@ -1374,6 +1396,7 @@ namespace ClassicUO.Game.GameObjects
                             }
                         }
                         else
+#endif // ENABLE_UOP
                         {
                             if (isRun)
                             {

--- a/src/ClassicUO.IO/UOFileUop.cs
+++ b/src/ClassicUO.IO/UOFileUop.cs
@@ -35,6 +35,7 @@ using System.Collections.Generic;
 
 namespace ClassicUO.IO
 {
+#if ENABLE_UOP
     public class UOFileUop : UOFile
     {
         private const uint UOP_MAGIC_NUMBER = 0x50594D;
@@ -276,4 +277,5 @@ namespace ClassicUO.IO
             return ((ulong) esi << 32) | eax;
         }
     }
+#endif // ENABLE_UOP
 }

--- a/src/ClassicUO.Renderer/Animations/Animation.cs
+++ b/src/ClassicUO.Renderer/Animations/Animation.cs
@@ -63,10 +63,12 @@ namespace ClassicUO.Renderer.Animations
         {
             ConvertBodyIfNeeded(ref animID);
 
+#if ENABLE_UOP
             if (uop)
             {
                 AnimationsLoader.Instance.ReplaceUopGroup(animID, ref group);
             }
+#endif
 
             uint packed32 = (uint)((group | (direction << 8) | ((uop ? 0x01 : 0x00) << 16)));
             uint packed32_2 = (uint)((animID | (frame << 16)));
@@ -161,6 +163,7 @@ namespace ClassicUO.Renderer.Animations
 
                     if (!indices.IsEmpty)
                     {
+#if ENABLE_UOP
                         if (index.Flags.HasFlag(AnimationFlags.UseUopAnimation))
                         {
                             index.UopGroups = new AnimationGroupUop[indices.Length];
@@ -174,6 +177,7 @@ namespace ClassicUO.Renderer.Animations
                             }
                         }
                         else
+#endif // ENABLE_UOP
                         {
                             index.Groups = new AnimationGroup[indices.Length / AnimationsLoader.MAX_DIRECTIONS];
                             for (int i = 0; i < index.Groups.Length; i++)
@@ -206,13 +210,17 @@ namespace ClassicUO.Renderer.Animations
                 }
             } while (index == null);
            
+#if ENABLE_UOP
             useUOP = index.Flags.HasFlag(AnimationFlags.UseUopAnimation);
+#endif
             index.Hue = hue;
 
+#if ENABLE_UOP
             if (useUOP)
             {
                 AnimationsLoader.Instance.ReplaceUopGroup(id, ref action);
             }
+#endif
 
             // NOTE:
             // for UOP: we don't call the method index.GetUopGroup(ref x) because the action has been already changed by the method ReplaceAnimationValues
@@ -244,6 +252,7 @@ namespace ClassicUO.Renderer.Animations
 
             if (animDir.FrameCount <= 0 || animDir.SpriteInfos == null)
             {
+#if ENABLE_UOP
                 if (useUOP
                 //animDir.IsUOP ||
                 ///* If it's not flagged as UOP, but there is no mul data, try to load
@@ -269,6 +278,7 @@ namespace ClassicUO.Renderer.Animations
                     );
                 }
                 else
+#endif // ENABLE_UOP
                 {
                     var ff = new AnimationsLoader.AnimIdxBlock()
                     {
@@ -352,7 +362,11 @@ namespace ClassicUO.Renderer.Animations
 
             ushort hue = 0;
 
-            if (_dataIndex[graphic] != null && _dataIndex[graphic].FileIndex == 0 && !_dataIndex[graphic].Flags.HasFlag(AnimationFlags.UseUopAnimation))
+            if (_dataIndex[graphic] != null && _dataIndex[graphic].FileIndex == 0
+#if ENABLE_UOP
+                && !_dataIndex[graphic].Flags.HasFlag(AnimationFlags.UseUopAnimation)
+#endif
+                )
                 _ = isCorpse ? AnimationsLoader.Instance.ReplaceCorpse(ref graphic, ref hue) : AnimationsLoader.Instance.ReplaceBody(ref graphic, ref hue);
         }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,6 +16,10 @@
     <Description>An open source implementation of the Ultima Online Classic Client.</Description>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ENABLE_UOP)' != 'false'">
+    <DefineConstants>$(DefineConstants);ENABLE_UOP</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IS_DEV_BUILD)' == 'true'">
     <DefineConstants>$(DefineConstants);DEV_BUILD</DefineConstants>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,10 @@
     <DefineConstants>$(DefineConstants);ENABLE_UOP</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ENABLE_MAPDIF)' != 'false'">
+    <DefineConstants>$(DefineConstants);ENABLE_MAPDIF</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IS_DEV_BUILD)' == 'true'">
     <DefineConstants>$(DefineConstants);DEV_BUILD</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
This allows building a leaner executable if a shard doesn't use these.