### PR TITLE
Use gump textures for backgammon board, but don't modify Y positions

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/ContainerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ContainerGump.cs
@@ -170,9 +170,10 @@ namespace ClassicUO.Game.UI.Gumps
         }
 
         public bool IsChessboard =>
-            Graphic
-            == 0x091A /*|| Graphic == 0x092E*/
-        ;
+            Graphic == 0x091A;
+
+        public bool IsBackgammonBoard =>
+            Graphic == 0x092E;
 
         private void BuildGump()
         {
@@ -387,7 +388,7 @@ namespace ClassicUO.Game.UI.Gumps
                         Rectangle containerBounds = World.ContainerManager.Get(gump.Graphic).Bounds;
 
                         ref readonly var spriteInfo = ref (
-                            gump.IsChessboard
+                            (gump.IsChessboard || gump.IsBackgammonBoard)
                                 ? ref Client.Game.UO.Gumps.GetGump(
                                     (ushort)(
                                         Client.Game.UO.GameCursor.ItemHold.DisplayedGraphic
@@ -555,7 +556,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private float GetScale()
         {
-            return IsChessboard ? 1f : UIManager.ContainerScale;
+            return (IsChessboard || IsBackgammonBoard) ? 1f : UIManager.ContainerScale;
         }
 
         private void ItemsOnAdded()
@@ -611,12 +612,12 @@ namespace ClassicUO.Game.UI.Gumps
                     item.Serial,
                     (ushort)(
                         item.DisplayedGraphic
-                        - (IsChessboard ? Constants.ITEM_GUMP_TEXTURE_OFFSET : 0)
+                        - ((IsChessboard || IsBackgammonBoard) ? Constants.ITEM_GUMP_TEXTURE_OFFSET : 0)
                     ),
                     item.Hue,
                     item.X,
                     item.Y,
-                    IsChessboard
+                    (IsChessboard || IsBackgammonBoard)
                 );
 
                 itemControl.IsVisible = !IsMinimized;
@@ -649,7 +650,7 @@ namespace ClassicUO.Game.UI.Gumps
             int boundHeight = dataBounds.Height + (IsChessboard ? 20 : 0);
 
             ref readonly var spriteInfo = ref (
-                IsChessboard
+                (IsChessboard || IsBackgammonBoard)
                     ? ref Client.Game.UO.Gumps.GetGump(
                         (ushort)(
                             item.DisplayedGraphic


### PR DESCRIPTION
Fix for this problem:
![screenshot-2024-09-29-07-56-50](https://github.com/user-attachments/assets/d3a9593d-bd35-43ef-bc0e-8e1764042c2d)

Looks like someone tried to fix this before, but backgammon boards need to be treated slightly differently from chess/checker boards - the Y offset should not be applied for them in the same way.