### PR TITLE
NetClient: use ReadAsync()

### DIFF
--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -92,7 +92,15 @@ namespace ClassicUO.Network
 
         public int Read(byte[] buffer)
         {
-            if (!IsConnected) return 0;
+            if (_socket == null) return 0;
+
+            if (!IsConnected)
+            {
+                OnDisconnected?.Invoke(this, EventArgs.Empty);
+                Disconnect();
+
+                return 0;
+            }
 
             var available = Math.Min(buffer.Length, _socket.Available);
             var done = 0;
@@ -127,6 +135,7 @@ namespace ClassicUO.Network
         public void Dispose()
         {
             _socket?.Dispose();
+            _socket = null;
         }
     }
 


### PR DESCRIPTION
Call ReadAsync() in a loop instead of calling Read() only when data is
available.  This allows detecting if the connection was closed by the
server.  Previously, this was only ever detected if Send() fails, but
if no data gets sent, we never learn about the disconnect.

For example, if the server closes the connection during AccountLogin,
the "Verifying Account" screen is stuck with no visual feedback.  This
is because the disconnect was never detected, but also because the
LoginScene does not check for disconnects.  The former is fixed by
this patch (a "Disconnected" warning gets logged), but the LoginScene
is still buggy.
